### PR TITLE
pin Werkzeug 0.16.1 as a workaround for test error

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,5 @@ flake8
 Flask-Testing==0.7.1
 gunicorn==19.6.0
 requests==2.20.0
+# pin to 0.16.1 as a workaround for https://github.com/jarus/flask-testing/issues/143
+Werkzeug==0.16.1


### PR DESCRIPTION
# What we're fixing
`cannot import name 'cached_property' from 'werkzeug'` error while running tests.

https://stackoverflow.com/questions/60156202/flask-app-wont-launch-importerror-cannot-import-name-cached-property-from-w

# What we've done here
pin Werkzeug version to 0.16.1

# How to verify these changes
run `pip install -r requirements.txt` and `py.test tests`

# Dependencies
none