### PR TITLE
Added support for dependency keywords with full issue/PR url

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,12 @@
 
 ## Key Features
 
-It checks for  dependant pull requests, both same-repo and external, which should be defined by keywords on either pull request's body or comments:
+It checks for dependant pull requests, both same-repo and external, which should be defined by keywords on either pull request's body or comments:
 
-* Same repo: Depends on #1
-* External: Depends on alvarocavalcanti/pierre-decheck#1
+* Same repo: `Depends on #1`
+* External:
+  * `Depends on alvarocavalcanti/pierre-decheck#1`
+  * `Depends on https://github.com/alvarocavalcanti/pierre-decheck/pull/1`
 
 Pierre will perform checks only upon PR creation and Comment Activity (added/removed). In every case it will fetch all the PR's bodies (the PR body itself and from all its comments), extract the dependencies and perform the checks. Thus, it **does not** observe the dependencies themselves and re-run the checks if their status change.
 
@@ -28,7 +30,7 @@ For now, the best way of re-checkind the dependencies statuses is to add a new c
 ## Usage
 
 1. Create a pull request on the repository that has *pierre* set up
-1. Add the keywords `Depends on #` (for same-repo) or "Depends on `owner/repo#`" (for external) followed by an issue/pull request number, `Depends on #2` or `Depends on owner/repo#2`, to the pull request description, or later, as a comment ![Pull Request Checks Example](docs/images/pull_request_keywords.png)
+1. Add the keywords `Depends on #` (for same-repo) or "Depends on `owner/repo#`" (for external) followed by an issue/pull request number, `Depends on #2` or `Depends on owner/repo#2`, to the pull request description, or later, as a comment. (Alternatively, `Depends on <GITHUB_URL_OF_ISSUE_OR_PR>` style can be used) ![Pull Request Checks Example](docs/images/pull_request_keywords.png)
 1. Every time a comment is added or deleted, *pierre* will check the dependencies and update the "Checks" section: ![Pull Request Checks Example](docs/images/pull_request_checks.png)
 
 ### Optional feature: Depending on a Released PR

--- a/lib/pierre.py
+++ b/lib/pierre.py
@@ -185,7 +185,10 @@ def get_owner_and_repo(event):
 def extract_dependency_id(comment_body):
     import re
     comment_body = comment_body.lower()
-    regex = r"{}(?:https\:\/\/github\.com\/)?([A-Za-z0-9-_]+\/[A-Za-z0-9-_]+)?(?:\#|\/issues\/|\/pull\/)(\d+)".format("depends on ")
+    regex = (
+        r"{}(?:https\:\/\/github\.com\/)?([A-Za-z0-9-_]+\/[A-Za-z0-9-_]+)?(?:\#|\/issues\/|\/pull\/)(\d+)"
+        .format("depends on ")
+    )
     match = re.findall(regex, comment_body)
     if match:
         items = []

--- a/lib/pierre.py
+++ b/lib/pierre.py
@@ -185,7 +185,7 @@ def get_owner_and_repo(event):
 def extract_dependency_id(comment_body):
     import re
     comment_body = comment_body.lower()
-    regex = r"(?:{})([A-Za-z0-9-_]+\/[A-Za-z0-9-_]+)*(?:\#)(\d*)".format("depends on ")
+    regex = r"{}(?:https\:\/\/github\.com\/)?([A-Za-z0-9-_]+\/[A-Za-z0-9-_]+)?(?:\#|\/issues\/|\/pull\/)(\d+)".format("depends on ")
     match = re.findall(regex, comment_body)
     if match:
         items = []
@@ -201,7 +201,7 @@ def extract_dependency_id(comment_body):
 
 def get_external_owner_and_repo(dependency_id):
     import re
-    regex = r"([A-Za-z0-9-_]+)(?:\/)([A-Za-z0-9-_]+)*(?:\#)(\d*)"
+    regex = r"([A-Za-z0-9-_]+)\/([A-Za-z0-9-_]+)\#(\d+)"
     match = re.findall(regex, dependency_id)
     if match:
         owner, repo, dependency_id = match[0]

--- a/tests/test_pierre.py
+++ b/tests/test_pierre.py
@@ -153,7 +153,10 @@ class TestPierre(PierreTestCase):
             self, requests_mock
     ):
         payload = PR_COMMENT_EVENT.replace("This is the PR body", "Depends on owner/repo#2.")
-        payload = json.loads(payload.replace("this is a comment", "Depends on https://github.com/owner/repo/pull/3. Depends on https://github.com/owner/repo/issues/4"))
+        payload = json.loads(payload.replace("this is a comment", (
+            "Depends on https://github.com/owner/repo/pull/3."
+            "Depends on https://github.com/owner/repo/issues/4."
+        )))
 
         response = check(payload, headers=GITHUB_HEADERS, host=HOST)
 


### PR DESCRIPTION
# What we're fixing
Github supports linking with issue/PR url, so I wanted to write dependency like `Depends on https://github.com/alvarocavalcanti/pierre-decheck/pull/72`.
I usually use this style for linking to issues in external repo, because it's easier to copy and paste :)

see: https://help.github.com/en/github/writing-on-github/autolinked-references-and-urls#issues-and-pull-requests

# What we've done here
- support dependency keywords with full issue/PR url
- some improvements to regex pattern

# How to verify these changes
Run tests.
