### PR TITLE
Updated : /details to support external dependencies with hyphen

### DIFF
--- a/server.py
+++ b/server.py
@@ -27,7 +27,10 @@ def webhook_event():
 @app.route("/details", methods=['GET'])
 def details():
     info = request.args.get('info')
-    dependencies_and_states = info.split('-')
+    #Modifying info to extract dependencies
+    info = info.split(':')
+    info = "".join(list(info[0]) + [dep.replace('-', ' ',1) for dep in info[1:]])
+    dependencies_and_states = info.split(' ')
     dependencies_info = [dep.replace(':', ' is ') for dep in dependencies_and_states]
 
     return {"dependencies": dependencies_info}, status.HTTP_200_OK


### PR DESCRIPTION
# What we're fixing
(REQUIRED)
Details endpoint does not support external dependencies with hyphen #25 

Fixes #25 

# What we've done here
(REQUIRED)
Modified the info variable. Replaced the hyphen(-) in between the dependencies with space ' '.
Then used this space to split the info into dependencies list.

DESCRIPTION

- ITEMS_LIST

# How to verify these changes
(REQUIRED)

1. Check with urls with external dependency with hyphen
2. Check with multiple dependencies as well

# Dependencies
(OPTIONAL)

Depends on #ISSUE_ID
